### PR TITLE
Add highlight for tool placeholders

### DIFF
--- a/NBC Board Export & Import [8.5, stable]-8.5.user.js
+++ b/NBC Board Export & Import [8.5, stable]-8.5.user.js
@@ -70,6 +70,14 @@
         el.textContent = msg;
     }
 
+    function addCustomStyles() {
+        if (document.getElementById('nbc-custom-styles')) return;
+        const style = document.createElement('style');
+        style.id = 'nbc-custom-styles';
+        style.textContent = '.nbc-highlight { background-color: yellow; }';
+        document.head.appendChild(style);
+    }
+
     // --- KORRIGIERTE Externe Tool URL-Extraktion basierend auf Netzwerkaufzeichnung ---
     async function extractExternalToolId(contextId) {
         return new Promise((resolve) => {
@@ -454,7 +462,7 @@
                 }
 
                 elementData.type = CONFIG.ELEMENT_TYPES.TEXT;
-                elementData.content = `An dieser Stelle muss das externe Tool ${toolType} hinzugefügt werden.`;
+                elementData.content = `<span class="nbc-highlight">An dieser Stelle muss das externe Tool ${toolType} hinzugefügt werden.</span>`;
                 elementData.shouldBeBold = true;
                 elementData.isExternalToolPlaceholder = true;
             }
@@ -1385,6 +1393,7 @@
 
     function initUI() {
         if (document.getElementById('nbc-ui')) return;
+        addCustomStyles();
 
         const wrapper = document.createElement('div');
         wrapper.id = 'nbc-ui';


### PR DESCRIPTION
## Summary
- highlight external tool placeholders in yellow
- inject custom CSS for highlighting

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6853f86d1f7083268421498e7c8fb58a