### PR TITLE
Implement optional caching and configurable headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,11 @@ werden im unteren rechten Bereich jeder Board-Seite zwei Schaltflächen eingeble
 
 Das Skript ist besonders hilfreich, um komplette Boards zu sichern oder zwischen
 Instanzen der NBC zu übertragen.
+
+## Konfiguration
+
+Im Skript befindet sich ein `CONFIG`-Block. 
+Mit der neuen Einstellung `CACHE_ENABLED` lassen sich Antworten von API-Aufrufen
+im Browser-Cache speichern und erneut verwenden. Ist das Flag aktiviert, werden
+keine "no-cache"-Header gesetzt und abgelegte Responses zuerst aus dem Cache
+geladen.


### PR DESCRIPTION
## Summary
- add `CACHE_ENABLED` setting to allow caching API responses
- add helper functions for header management and Cache API usage
- use caching in `extractExternalToolId` and `fetchContextIdFromApi`
- document cache setting in README

## Testing
- `node -v`
- `node -e "require('fs').readFileSync('NBC Board Export & Import [8.5, stable]-8.5.user.js','utf8')" >/dev/null`

------
https://chatgpt.com/codex/tasks/task_b_6853fee28cc88326bac081add7fb941c