### PR TITLE
Add circular emoji buttons

### DIFF
--- a/NBC Board Export & Import [8.8, stable]-8.8.user.js
+++ b/NBC Board Export & Import [8.8, stable]-8.8.user.js
@@ -76,7 +76,28 @@
         if (document.getElementById('nbc-custom-styles')) return;
         const style = document.createElement('style');
         style.id = 'nbc-custom-styles';
-        style.textContent = '.nbc-highlight { background-color: yellow; }';
+        style.textContent = `
+            .nbc-highlight { background-color: yellow; }
+            #nbc-ui button {
+                width: 48px;
+                height: 48px;
+                border: none;
+                border-radius: 50%;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                font-size: 20px;
+                line-height: 1;
+                cursor: pointer;
+                color: #fff;
+            }
+            #nbc-ui button .nbc-letter {
+                font-size: 10px;
+            }
+            #nbc-ui .nbc-export { background: #2196f3; }
+            #nbc-ui .nbc-import { background: #4caf50; }
+        `;
         document.head.appendChild(style);
     }
 
@@ -1414,29 +1435,13 @@
         });
 
         const expBtn = document.createElement('button');
-        expBtn.textContent = 'Export v8.8';
-        Object.assign(expBtn.style, {
-            padding: '8px 12px',
-            border: 'none',
-            borderRadius: '4px',
-            background: '#2196f3',
-            color: '#fff',
-            cursor: 'pointer',
-            fontSize: '12px'
-        });
+        expBtn.className = 'nbc-export';
+        expBtn.innerHTML = `<span class="nbc-letter">E</span>📤`;
         expBtn.addEventListener('click', exportBoard);
 
         const impBtn = document.createElement('button');
-        impBtn.textContent = 'Import';
-        Object.assign(impBtn.style, {
-            padding: '8px 12px',
-            border: 'none',
-            borderRadius: '4px',
-            background: '#4caf50',
-            color: '#fff',
-            cursor: 'pointer',
-            fontSize: '12px'
-        });
+        impBtn.className = 'nbc-import';
+        impBtn.innerHTML = `<span class="nbc-letter">I</span>📥`;
 
         const fileInput = document.createElement('input');
         fileInput.type = 'file';


### PR DESCRIPTION
## Summary
- style the UI buttons as circles with flexbox layout
- show `E` or `I` above an emoji inside the buttons

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68570100d4748326ab566d6bd214e4e6