### PR TITLE
Add board title to export/import

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ werden im unteren rechten Bereich jeder Board-Seite zwei Schaltflächen eingeble
 
 ## Hauptfunktionen
 
-* Exportiert Spalten, Karten und alle unterstützten Inhaltstypen (z. B. Textfelder,
-  Dateien, Links, Videokonferenzen und Platzhalter für externe Tools) in eine
-  strukturierte JSON-Datei.
-* Importiert ein solches JSON-Archiv wieder und stellt dabei möglichst die gesamte
-  Board-Struktur her.
+* Exportiert Spalten, Karten, den Boardtitel und alle unterstützten Inhaltstypen
+  (z. B. Textfelder, Dateien, Links, Videokonferenzen und Platzhalter für externe
+  Tools) in eine strukturierte JSON-Datei.
+* Importiert ein solches JSON-Archiv wieder und stellt dabei möglichst die
+  gesamte Board-Struktur inklusive des Boardtitels her.
 * Erkennt verschiedene Exportversionen und passt den Import entsprechend an.
 * Fügt eine kleine Benutzeroberfläche mit Export- und Import-Schaltflächen direkt
   in die Board-Seite ein.


### PR DESCRIPTION
## Summary
- export board title alongside columns and cards
- set board title before creating columns during import
- document board title handling in README

## Testing
- `node --check 'NBC Board Export & Import [8.8, stable]-8.8.user.js'`

------
https://chatgpt.com/codex/tasks/task_b_6859117613b48326bd12b87f9f3e680e